### PR TITLE
chore: Update Path Handling and Code Style Improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,7 @@ name = "aztec-sandbox"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "dirs",
  "flate2",
  "reqwest",
  "tar",
@@ -107,6 +108,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bumpalo"
@@ -191,6 +198,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,7 +234,7 @@ checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "windows-sys",
 ]
 
@@ -294,6 +321,17 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -454,9 +492,20 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+
+[[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall 0.4.1",
+]
 
 [[package]]
 name = "log"
@@ -563,7 +612,27 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -777,6 +846,26 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ reqwest = { version = "0.11.16", default-features = false, features = [
 ] }
 tar = "0.4"
 flate2 = "1.0"
+dirs = "4.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,25 +95,22 @@ fn install(tag: &str) {
 
 fn use_version(version: &str) {
     // TODO: deprecated home dir command -> look in noir
-    let path =
-        PathBuf::from(AZTEC_DIR.replace("~", &std::env::home_dir().unwrap().to_string_lossy()))
-            .join("version");
+    let path = PathBuf::from(AZTEC_DIR.replace('~', &dirs::home_dir().unwrap().to_string_lossy()))
+        .join("version");
     fs::write(path, version).expect("Failed to write to version file.");
     println!("Set version to: {}", version);
 }
 
 fn write_compose_text() {
-    let path =
-        PathBuf::from(AZTEC_DIR.replace("~", &std::env::home_dir().unwrap().to_string_lossy()))
-            .join("run");
+    let path = PathBuf::from(AZTEC_DIR.replace('~', &dirs::home_dir().unwrap().to_string_lossy()))
+        .join("run");
     if !path.exists() {
         fs::write(path, COMPOSE_TEXT).expect("Failed to write to compose file.");
     }
 }
 
 fn run() {
-    let base =
-        PathBuf::from(AZTEC_DIR.replace("~", &std::env::home_dir().unwrap().to_string_lossy()));
+    let base = PathBuf::from(AZTEC_DIR.replace('~', &dirs::home_dir().unwrap().to_string_lossy()));
     let compose_path = &base.join("run");
     // TODO:cleanup
     write_compose_text();
@@ -169,7 +166,7 @@ fn update() {
     let mut archive = Archive::new(tar);
 
     let aztec_dir =
-        PathBuf::from(AZTEC_DIR.replace("~", &std::env::home_dir().unwrap().to_string_lossy()));
+        PathBuf::from(AZTEC_DIR.replace('~', &dirs::home_dir().unwrap().to_string_lossy()));
     archive
         .unpack(&aztec_dir.join("bin"))
         .expect("Could not unpack archive");
@@ -217,7 +214,7 @@ fn get_tar_url() -> Result<String, String> {
         "arm64" => arch_string = "aarch64".to_string(),
         "x86_64" | "aarch64" => {}
         _ => {
-            eprintln!("unsupported architecture: {}-{}", arch_string, "PLATFORM");
+            eprintln!("unsupported architecture: {}-PLATFORM", arch_string);
             return Err("unsupported arch".into());
         }
     }
@@ -230,5 +227,5 @@ fn get_tar_url() -> Result<String, String> {
         release_url, arch_string, plat_string
     );
 
-    return Ok(bin_tarball_url);
+    Ok(bin_tarball_url)
 }


### PR DESCRIPTION
## Changes
This PR implements several updates to the Aztec Sandbox Version Manager, focusing on improving cross-platform compatibility and adhering to Rust best practices:

- Replaced `std::env::home_dir` with `dirs::home_dir` to ensure consistent behavior across platforms.
- Optimized string manipulations by using char patterns in `replace` method.
- Removed unnecessary `return` statements, aligning with idiomatic Rust code style.
- Addressed all `Clippy` warnings and enforced code formatting with `cargo fmt`.
- Verified compatibility with different platforms and architectures.

## Motivation
These updates aim to enhance the maintainability, efficiency, and readability of the code, ensuring a robust and developer-friendly environment.

## Tests and Checks
- Code has been formatted using `cargo fmt`.
- Lint checks passed with `cargo clippy`.
